### PR TITLE
Update time on app resume and on timer

### DIFF
--- a/ttc_service_alerts/lib/components/TweetCardList.dart
+++ b/ttc_service_alerts/lib/components/TweetCardList.dart
@@ -96,6 +96,7 @@ class _TweetCardListState extends State<TweetCardList>
     }
 
     // Make the request for the updated tweets
+    // TODO TimeoutException (TimeoutException after 0:00:10.000000: Future not completed)
     Response res = await widget._twitterOauth.getTwitterRequest(
       "GET",
       "statuses/user_timeline.json",
@@ -111,6 +112,8 @@ class _TweetCardListState extends State<TweetCardList>
       setState(() {
         widget._tweets = [...newTweetItems, ...widget._tweets];
 
+        // If there is a new tweet, update the most recent tweet to be used by
+        // the next fetch
         if (newTweetItems.length > 0) {
           widget._mostRecentTweet = newTweetItems[0].tweetId;
         }

--- a/ttc_service_alerts/lib/config/config.dart
+++ b/ttc_service_alerts/lib/config/config.dart
@@ -11,6 +11,4 @@ const double chipFontSize = 16.0;
 const double timeFontSize = 14.0;
 
 /// This controls how often the feed is updated
-const int feedUpdateMinutes = 5;
-/// This controls how often the "How Long Ago" time is updated
-const int tweetTimeUpdateMinutes = 5;
+const int feedUpdateMinutes = 3;


### PR DESCRIPTION
- This existed previously but was done in a way that was not very smart
  - One timer for each time that needed to be updated was created
  - Now there is only one timer that updates the feed as well as updates
    every tweets times
  - Times are also updated when a card comes back into view (when scrolling)
  - Times are also updated when app is resumed